### PR TITLE
Migrated ABI fetching from Etherscan to Sourcify

### DIFF
--- a/docs/pages/usage_cli.md
+++ b/docs/pages/usage_cli.md
@@ -77,7 +77,7 @@ It can be called with single files or directories, in which case all descriptors
 
 The `generate` command bootstraps a new descriptor file from ABIs or message schemas:
 ```shell
-# fetch ABIs from etherscan and generate a new calldata descriptor
+# fetch ABIs from Sourcify and generate a new calldata descriptor
 erc7730 generate --chain-id=1 --address=0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45
 
 # generate a new calldata descriptor using given ABI file
@@ -87,10 +87,6 @@ erc7730 generate --chain-id=1 --address=0x00000000000000000000000000000000000000
 erc7730 generate --chain-id=1 --address=0x0000000000000000000000000000000000000000 --schema schemas.json
 ```
 
-To fetch ABIs automatically, you will need to [setup an Etherscan API key](https://docs.etherscan.io/getting-started/viewing-api-usage-statistics):
-```shell
-export ETHERSCAN_API_KEY=XXXXXX
-```
 
 Please note that while the generator does its best to guess the right format based on fields name/type, the generated
 descriptor should be considered a starting point to refine.

--- a/src/erc7730/generate/generate.py
+++ b/src/erc7730/generate/generate.py
@@ -56,7 +56,7 @@ def generate_descriptor(
     Generate an ERC-7730 descriptor.
 
     If an EIP-712 schema is provided, an EIP-712 descriptor is generated for this schema, otherwise a calldata
-    descriptor. If no ABI is supplied, the ABIs are fetched from Etherscan using the chain id / contract address.
+    descriptor. If no ABI is supplied, the ABIs are fetched from Sourcify using the chain id / contract address.
 
     :param chain_id: contract chain id
     :param contract_address: contract address
@@ -109,7 +109,7 @@ def _generate_context_calldata(
         abis = TypeAdapter(list[ABI]).validate_json(abi)
 
     elif (abis := get_contract_abis(chain_id, contract_address)) is None:
-        raise Exception("Failed to fetch contract ABIs")
+        raise Exception("Failed to fetch contract ABIs from Sourcify")
 
     functions = list(get_functions(abis).functions.values())
 

--- a/src/erc7730/model/abi.py
+++ b/src/erc7730/model/abi.py
@@ -7,7 +7,7 @@ See https://docs.soliditylang.org/en/latest/abi-spec.html
 from enum import StrEnum
 from typing import Annotated, Literal, Self
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from erc7730.model.base import Model
 
@@ -48,6 +48,18 @@ class Function(Model):
     gas: int | None = None
     signature: str | None = None
 
+    @field_validator('stateMutability', mode='before')
+    @classmethod
+    def validate_state_mutability(cls, v):
+        if v is None:
+            return v
+        if isinstance(v, StateMutability):
+            return v
+        try:
+            return StateMutability(v)
+        except Exception:
+            return v
+
 
 class Constructor(Model):
     type: Literal["constructor"] = "constructor"
@@ -59,6 +71,18 @@ class Constructor(Model):
     payable: bool | None = None
     gas: int | None = None
     signature: str | None = None
+
+    @field_validator('stateMutability', mode='before')
+    @classmethod
+    def validate_state_mutability(cls, v):
+        if v is None:
+            return v
+        if isinstance(v, StateMutability):
+            return v
+        try:
+            return StateMutability(v)
+        except Exception:
+            return v
 
 
 class Receive(Model):
@@ -72,6 +96,18 @@ class Receive(Model):
     gas: int | None = None
     signature: str | None = None
 
+    @field_validator('stateMutability', mode='before')
+    @classmethod
+    def validate_state_mutability(cls, v):
+        if v is None:
+            return v
+        if isinstance(v, StateMutability):
+            return v
+        try:
+            return StateMutability(v)
+        except Exception:
+            return v
+
 
 class Fallback(Model):
     type: Literal["fallback"] = "fallback"
@@ -83,6 +119,18 @@ class Fallback(Model):
     payable: bool | None = None
     gas: int | None = None
     signature: str | None = None
+
+    @field_validator('stateMutability', mode='before')
+    @classmethod
+    def validate_state_mutability(cls, v):
+        if v is None:
+            return v
+        if isinstance(v, StateMutability):
+            return v
+        try:
+            return StateMutability(v)
+        except Exception:
+            return v
 
 
 class Event(Model):


### PR DESCRIPTION
### Switch contract ABI fetching from Etherscan to Sourcify

- Replaced all Etherscan API usage with Sourcify’s open-source contract repository.
- Updated the HTTP client to properly follow redirects and bypass cache for Sourcify endpoints.
- Improved ABI validation:
  - Added support for string values of `stateMutability` (as returned by Sourcify) in the Pydantic models.
- Updated documentation and CLI help:
  - Sourcify is now the default ABI source.
  - Clarified that no API key is required.
- Removed all dependencies and references to Etherscan.

**Result:**  
The tool now fetches contract ABIs directly from Sourcify, with better reliability, no API key requirement, and full compatibility with contracts verified on Sourcify.